### PR TITLE
change pegs.buildParser to pegjs.generate

### DIFF
--- a/source/pegify.js
+++ b/source/pegify.js
@@ -102,7 +102,7 @@ Pegify.getExtensions = function (options) {
  * @return {!String}
  */
 Pegify.prototype.compile = function (content) {
-  return this._options.export + '=' + pegjs.buildParser(content, this._options);
+  return this._options.export + '=' + pegjs.generate(content, this._options);
 };
 
 /**


### PR DESCRIPTION
This supports the current versions of pegjs, which no longer uses buildParser. Thanks for this library!